### PR TITLE
fix: respect PCCS_URL environment variable in entry.sh

### DIFF
--- a/src/entry.sh
+++ b/src/entry.sh
@@ -6,7 +6,7 @@ if [ ! -L /dev/sgx/enclave ]; then
 	ln -s /dev/sgx_enclave /dev/sgx/enclave
 fi
 
-PCCS_URL=https://global.acccache.azure.net/sgx/certification/v4/
+PCCS_URL=${PCCS_URL:-https://global.acccache.azure.net/sgx/certification/v4/}
 echo "PCCS_URL: ${PCCS_URL}"
 
 apt-get install -qq libsgx-dcap-default-qpl


### PR DESCRIPTION
The entry.sh script was hardcoding PCCS_URL to Azure's global cache, which prevented environment variables from being respected. This change uses bash parameter expansion to allow PCCS_URL to be overridden via environment variables while maintaining backward compatibility with the Azure default.

This enables bare-metal SGX deployments to use local PCCS services required for attestation in non-Azure environments.