### PR TITLE
fix: respect PCCS_URL environment variable and fix config file format

### DIFF
--- a/src/entry.sh
+++ b/src/entry.sh
@@ -6,11 +6,11 @@ if [ ! -L /dev/sgx/enclave ]; then
 	ln -s /dev/sgx_enclave /dev/sgx/enclave
 fi
 
-PCCS_URL=https://global.acccache.azure.net/sgx/certification/v4/
+PCCS_URL=${PCCS_URL:-https://global.acccache.azure.net/sgx/certification/v4/}
 echo "PCCS_URL: ${PCCS_URL}"
 
 apt-get install -qq libsgx-dcap-default-qpl
 
-echo "PCCS_URL=${PCCS_URL}\nUSE_SECURE_CERT=FALSE" > /etc/sgx_default_qcnl.conf
+printf "PCCS_URL=%s\nUSE_SECURE_CERT=FALSE\n" "${PCCS_URL}" > /etc/sgx_default_qcnl.conf
 
 ./edb "$@"


### PR DESCRIPTION
## Summary
- Use bash parameter expansion to allow PCCS_URL to be overridden via environment variables while maintaining backward compatibility with the Azure default
- Fix the config file format by using `printf` instead of `echo` to properly write newlines to `/etc/sgx_default_qcnl.conf`

The entry.sh script had two issues:
1. Hardcoded PCCS_URL to Azure's global cache, preventing env var overrides
2. Used `echo` with `\n` which doesn't expand to newline in `/bin/sh`

This ensures `/etc/sgx_default_qcnl.conf` has proper format:
```
PCCS_URL=<url>
USE_SECURE_CERT=FALSE
```

This enables bare-metal SGX deployments to use local PCCS services required for attestation in non-Azure environments.

## Test plan
- [ ] Deploy EdgelessDB with custom PCCS_URL environment variable
- [ ] Verify `/etc/sgx_default_qcnl.conf` contains properly formatted config with two lines
- [ ] Verify attestation works with local PCCS service

🤖 Generated with [Claude Code](https://claude.com/claude-code)